### PR TITLE
Use HoH Preferred Name for Address

### DIFF
--- a/etc/ordering_script_config_map.py
+++ b/etc/ordering_script_config_map.py
@@ -58,6 +58,8 @@ project_dict = {
         "study_region": "Project Name",
         "pre_scan_barcode": "Collection",
         "back_end_scan": "BEMS",
+        "manage_hh_reporter": "HH Reporter",
+        "participant_pref_first_name": "Pref First Name",
     },
     "AIRS": {
         "project_id": "1372",


### PR DESCRIPTION
This change uses the HoH preferred name for shipments to a given household. We use
the head of household's enrollment address if a more recently updated address for
the household does not exist.

This change also fixes a bug where participant metadata like name, delivery instructions, and email/phone were not being pulled into the order sheet.