### PR TITLE
Cascadia Return Logging and BugFix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,8 @@ etc/fake.py
 .config/logistics*
 .config/gspread_pandas/*
 .env/redcap/REDCAP_API_TOKEN*
+.env/de
+.env/email
+.env/redcap_old
 .vscode
 __pycache__

--- a/orders/cascadia_return.py
+++ b/orders/cascadia_return.py
@@ -7,80 +7,103 @@ from datetime import datetime as dt
 import pandas as pd
 import envdir
 import requests
+import logging
 
 base_dir = path.abspath(__file__ + "/../../")
 envdir.open(path.join(base_dir, '.env/de'))
 envdir.open(path.join(base_dir, '.env/redcap'))
 
+LOG_LEVEL = environ.get('LOG_LEVEL', 'INFO')
+logging.basicConfig()
+LOG = logging.getLogger(__name__)
+LOG.setLevel(LOG_LEVEL)
+
+PROJECT = "Cascadia"
 
 def main():
-    project = "Cascadia"
-    redcap_project = init_project(project)
-    redcap_orders = get_redcap_orders(redcap_project, project)
-    if len(redcap_orders) == 0:
-        print('no orders')
-        return
-    redcap_orders = format_longitudinal(project, redcap_orders)
-    redcap_orders['Project Name'] = redcap_orders.apply(
-        lambda row: assign_project(row, project), axis=1)
-    redcap_orders['orderId'] = redcap_orders.dropna(
-        subset=['Record Id']).apply(get_de_orders, axis=1)
+    redcap_project = init_project(PROJECT)
+    redcap_orders = get_redcap_orders(redcap_project, PROJECT)
 
+    if len(redcap_orders) == 0:
+        LOG.info(f'No orders to process, exiting...')
+        return
+
+    redcap_orders = format_longitudinal(PROJECT, redcap_orders)
+    redcap_orders['Project Name'] = redcap_orders.apply(
+        lambda row: assign_project(row, PROJECT), axis=1
+    )
+    redcap_orders = redcap_orders.astype({'Record Id': int})
+    redcap_orders['orderId'] = redcap_orders.dropna(
+        subset=['Record Id']).apply(get_de_orders, axis=1
+    )
     formatted_import = format_orders_import(redcap_orders)
     redcap_project.import_records(formatted_import, overwrite='overwrite')
 
 
 def get_de_orders(redcap_order: pd.Series):
     url = "https://deliveryexpresslogistics.dsapp.io/integration/api/v1/orders/search"
+
     username_pass = bytearray(environ['AUTHORIZATION'], 'utf-8')
     base64_encoded = base64.b64encode(username_pass).decode('ascii')
     auth = f'Basic {base64_encoded}'
+
     payload = {
         "query": redcap_order.loc['Record Id'],
         "searchFields": ["referenceNumber1"]
     }
     headers = {'Authorization': auth, "Content-Type": "application/*+json"}
-    print(f'looking up order for pt: {redcap_order["Record Id"]}')
+
+    LOG.debug(f'Making request to <{url}> with data <{payload}>')
     response = requests.post(url, headers=headers, data=json.dumps(payload))
     de_orders = json.loads(response.text)
+
+    LOG.info(f'Looking up order for pt: <{redcap_order["Record Id"]}>.')
+
     if de_orders['totalCount'] == 0:
-        print(f'no orders found for {redcap_order["Record Id"]}')
-        return pd.NA
+        LOG.info(f'No orders found for <{redcap_order["Record Id"]}>.')
+        return None
+
     return extract_data(redcap_order, de_orders)
 
 
 def extract_data(redcap_order: pd.Series, de_orders: dict):
     for order in de_orders['items']:
-        print(
-            f"DE record id: {order['referenceNumber1']} real record id: {redcap_order['Record Id']}"
-        )
+        LOG.debug(f"DE record id is: {order['referenceNumber1']}; REDCap record id is: {redcap_order['Record Id']}")
+
         if str(order['referenceNumber1']) != str(redcap_order['Record Id']):
-            print('Record Ids do not match')
+            LOG.warning(f'Record Ids do not match, skipping order out of an abundance of caution.')
             continue
+
         if not 'CASCADIA' in order['referenceNumber3']:
-            print('Project Names do not match')
+            LOG.warning('Project Names do not match, skipping order out of an abundance of caution')
             continue
-        formatted_date = order['createdAt'][:19] + order['createdAt'][
-            -6:].replace(':', '')
-        created_date = dt.strptime(formatted_date,
-                                   '%Y-%m-%dT%H:%M:%S%z').replace(tzinfo=None)
+
+        formatted_date = order['createdAt'][:19] + order['createdAt'][-6:].replace(':', '')
+        created_date = dt.strptime(formatted_date, '%Y-%m-%dT%H:%M:%S%z').replace(tzinfo=None)
         order_date = redcap_order['Order Date']
-        print(f'{created_date.date()}  |  {order_date.date()}')
+
+        LOG.debug(f'DE Order Creation Date: <{created_date.date()}>. REDCap Order Date <{order_date.date()}>.')
         if (created_date > order_date):
             # referenceNumber1 record id
             # referenceNumber3 project
-            print(f'update record with {order["orderId"]}')
+            LOG.info(f'Updating REDCap record with <{order["orderId"]}>.')
             return order['orderId']
-    print('did not update redcap')
-    return pd.NA
+        else:
+            LOG.debug(f'DE Order creation date was before REDCap order creation date ({created_date.date()} < {order_date.date()}). Skipping order.')
+
+    LOG.info(f'Skipped REDCap update for Record ID <{redcap_order["Record Id"]}>, nothing to update.')
+    return None
 
 
 def format_orders_import(orders):
-    return orders[[
-        'orderId', 'redcap_repeat_instance', 'redcap_repeat_instrument'
-    ]].dropna(subset=['orderId']).rename(columns={
-        'orderId': 'ss_return_tracking'
-    }).reset_index().to_dict('records')
+    LOG.debug(f'Formatting <{len(orders)}> for import to REDCap.')
+    return orders[
+        ['orderId', 'redcap_repeat_instance', 'redcap_repeat_instrument']
+    ].dropna(
+        subset=['orderId']
+    ).rename(
+        columns={'orderId': 'ss_return_tracking'}
+    ).reset_index().to_dict('records')
 
 
 if __name__ == "__main__":

--- a/orders/delivery_express_order.py
+++ b/orders/delivery_express_order.py
@@ -145,14 +145,15 @@ def format_longitudinal(project, orders):
         )
 
         # orders we must fulfill are symptom surveys without an existing tracking number
-        # and which have a designated pickup time. We can drop records which do not have
-        # a order date. We only need to schedule max one pickup per participant so can
-        # simply keep the final index entry associated with them. Finally we should also
-        # apply the best address for each remaining row of the order sheet.
+        # which have a designated pickup time and have a swab trigger. We can drop records
+        # which do not have a order date. We only need to schedule max one pickup per
+        # participant so can simply keep the final index entry associated with them. Finally
+        # we should also apply the best address for each remaining row of the order sheet.
         orders = orders[
             (orders['redcap_repeat_instrument'] == 'symptom_survey') &
             (orders['ss_return_tracking'].isna()) &
-            any(orders[['Pickup 1', 'Pickup 2']].notna())
+            any(orders[['Pickup 1', 'Pickup 2']].notna()) &
+            (orders['ss_trigger_swab'])
         ] \
         .dropna(subset=['Order Date']) \
         .query("~index.duplicated(keep='last')") \


### PR DESCRIPTION
This change fixes a bug that meant Record IDs were being cast as floats,
which prevented them from being linked to DE order IDs. This prevented
the order IDs from being properly inserted into the REDCap project.

This change also adds basic logging functionality to the script for
ease of use in the future. Future steps will send these log messages
to some sort of file handler.