### PR TITLE
Suspend Deliveries When a Participant is Under Study Pause

### DIFF
--- a/orders/utils/cascadia.py
+++ b/orders/utils/cascadia.py
@@ -204,3 +204,29 @@ def get_head_of_household(household_records, house_id):
         LOG.debug(f"Found index <{int(head_of_house_idx)}> to be the head of household for household <{house_id}>.")
 
     return int(head_of_house_idx)
+
+
+def participant_under_study_pause(study_pauses, household_id, participant_index):
+    """Determines whether a given participant has their study paused at the moment"""
+    LOG.debug(f'Determining study pause status for participant <{participant_index}> in household <{household_id}>.')
+
+    # Participant can't be on a pause if they do not exist in the pause report
+    if not any(study_pauses.index.isin([((household_id, participant_index))])):
+        LOG.debug(f'Participant <{participant_index}> in household <{household_id}> is not currently under a study pause.')
+        return False
+
+    participant_pauses = study_pauses.loc[(household_id, participant_index),:]
+    current_date = datetime.datetime.today().strftime('%Y-%m-%d')
+
+    # Grab any currently active pauses from the df of participant pause date ranges
+    active_pauses = participant_pauses[
+        (participant_pauses['cl_study_pause_start'] <= current_date) &
+        (participant_pauses['cl_study_pause_end'] >= current_date)
+    ]
+
+    if not active_pauses.empty:
+        LOG.debug(f'Participant <{participant_index}> in household <{household_id}> is under a study pause until <{active_pauses.iloc[-1]["cl_study_pause_end"]}>')
+        return True
+    else:
+        LOG.debug(f'Participant <{participant_index}> in household <{household_id}> is not currently under a study pause.')
+        return False

--- a/orders/utils/redcap.py
+++ b/orders/utils/redcap.py
@@ -87,3 +87,14 @@ def get_redcap_report(redcap_project, project_name, report_id = None):
 
     LOG.debug(f'Original report <{report_id}> for project <{project_name}> has <{len(report)}> rows.')
     return report.sort_index()
+
+
+def get_cascadia_study_pause_reports(project):
+    """Gets and concatenates Cascadia study pauses into one report"""
+    LOG.debug(f'Fetching <{len(STUDY_PAUSE_REPORT_IDS)}> Cascadia study pause reports.')
+    cascadia_study_pauses = pd.concat(
+        [get_redcap_report(project, 'Cascadia', report_id) for report_id in STUDY_PAUSE_REPORT_IDS]
+    )
+
+    LOG.debug(f'Concatenated pause report has <{len(cascadia_study_pauses)}> pause events.')
+    return cascadia_study_pauses.sort_index()


### PR DESCRIPTION
Prior to this change, whether or not a participant was under a study pause was not taken
into account when sending them kits. Now, participants will not be sent kits while they
are under study pause. The logic flow will skip kit ordering for them and once their
pause has ended kit ordering for the patient will resume.