### PR TITLE
Ensure Cascadia Orders Have Complete Symptom Survey

### DIFF
--- a/orders/utils/cascadia.py
+++ b/orders/utils/cascadia.py
@@ -56,7 +56,8 @@ def filter_cascadia_orders(orders):
         (orders['redcap_repeat_instrument'] == 'symptom_survey') &
         (orders['ss_return_tracking'].isna()) &
         any(orders[['Pickup 1', 'Pickup 2']].notna()) &
-        (orders['ss_trigger_swab'])
+        (orders['ss_trigger_swab']) &
+        (orders['symptom_survey_complete'])
     ].dropna(subset=['Order Date']
     ).query("~index.duplicated(keep='last')"
     ).apply(lambda record: use_best_address(enrollment_records, record), axis=1)


### PR DESCRIPTION
This change adds an additional filter for Cascadia participants that ensures they have a completed symptom survey. The REDCap report is supposed to filter out records that have incomplete surveys, but it does so inconsistently it seems. The three most recent issues with unnecessary pickups involved participants with incomplete symptom surveys, so this change should more effectively filter those records out of the order sheet.