### PR TITLE
Drop Records with a Duplicated Index before Importing to REDCap

### DIFF
--- a/orders/cascadia_return.py
+++ b/orders/cascadia_return.py
@@ -2,7 +2,7 @@
 import envdir, os, logging, argparse
 from utils.redcap import init_project, get_redcap_report, format_longitudinal
 from utils.delivery_express import get_de_orders, format_orders_import
-from utils.cascadia import filter_cascadia_orders
+from utils.cascadia import filter_cascadia_orders, drop_repeat_swabs
 
 base_dir = os.path.abspath(__file__ + "/../../")
 envdir.open(os.path.join(base_dir, '.env/de'))
@@ -27,6 +27,7 @@ def main(args):
 
     redcap_orders = format_longitudinal(redcap_orders, PROJECT)
     redcap_orders = filter_cascadia_orders(redcap_orders, redcap_enrollments)
+    redcap_orders = drop_repeat_swabs(redcap_orders, 'Order Date')
 
     redcap_orders = redcap_orders.astype({'Record Id': int})
     redcap_orders['orderId'] = redcap_orders.dropna(

--- a/orders/utils/delivery_express.py
+++ b/orders/utils/delivery_express.py
@@ -69,7 +69,7 @@ def extract_de_orders(redcap_order: pd.Series, de_orders: dict):
 
 def format_orders_import(orders):
     """Format the DE orders so they may be imported into REDCap"""
-    LOG.debug(f'Formatting and verifying record <{len(orders)}> for import to REDCap.')
+    LOG.debug(f'Formatting and verifying <{len(orders)}> records for import to REDCap.')
     return orders[
         ['orderId', 'redcap_repeat_instance', 'redcap_repeat_instrument']
     ].dropna(


### PR DESCRIPTION
Prior to this change, the DE tracking number would be piped into every matching
record ID in the DE order report. This implicitly assumed that a participant
would not show up in the report two days in a row and have both rows be populated
by the same order number.

This change drops any rows with a duplicated index, removing this assumption and
making it explicit that we only want to pipe order numbers back to one order per
participant per day. The assumption here is that we want to pipe this number back
to the older order, since this is the one that will have an order number generated
for it already. This should be a much safer assumption and eliminate this bug, which
was causing DE to skip pickups if a participant swabbed two days in a row and both
swab records were populated by this script.