### PR TITLE
Batch and retry return api requests

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -17,6 +17,7 @@ boto3 = "*"
 fsspec = "*"
 s3fs = "*"
 pyyaml = "*"
+more_itertools = "*"
 
 [dev-packages]
 yapf = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9834e3fa486fb04bc08106e0ad164842af2f1f0623c84f94aa9c4e3a0bfabf7a"
+            "sha256": "9817177bc51e235c7ead5c75a8010a0ed810160b68e0fc5d48f6b8fb9e0744ff"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,18 +18,19 @@
     "default": {
         "boto3": {
             "hashes": [
-                "sha256:bcc579e801774cb2c7dda87ff985feda1ae7e10591d11ef37526363139138bd4"
+                "sha256:3c6cc4e9e38cf4523267f89eb90c0b6084fa415cb4f44e3bf0cad6199340cc92",
+                "sha256:d28bcb98aee4d333b163c55b98341627d933dbf088832f7fc050893617be7dac"
             ],
             "index": "pypi",
-            "version": "==1.24.87"
+            "version": "==1.24.92"
         },
         "botocore": {
             "hashes": [
-                "sha256:216de9751116d0d1cc3901e26d95a5c9a30ecb6973ae6147af1cf504858d845a",
-                "sha256:c4cbd22056ace4c7aa99e62e8ae629865ab80cc8bbf7c6d68ccf0f768f0034b6"
+                "sha256:70cf2cb04968794ed4688cc3b07874f6f4c932e325611be4e693a995fdb481be",
+                "sha256:b49c34b80c782625905be75e669da4b42a99f074e0aa3007e15ccc6955682a07"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.27.87"
+            "version": "==1.27.92"
         },
         "cachetools": {
             "hashes": [
@@ -96,11 +97,11 @@
         },
         "google-auth": {
             "hashes": [
-                "sha256:98f601773978c969e1769f97265e732a81a8e598da3263895023958d456ee625",
-                "sha256:f12d86502ce0f2c0174e2e70ecc8d36c69593817e67e1d9c5e34489120422e4b"
+                "sha256:9352dd6394093169157e6971526bab9a2799244d68a94a4a609f0dd751ef6f5e",
+                "sha256:99510e664155f1a3c0396a076b5deb6367c52ea04d280152c85ac7f51f50eb42"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==2.12.0"
+            "version": "==2.13.0"
         },
         "google-auth-oauthlib": {
             "hashes": [
@@ -112,11 +113,11 @@
         },
         "gspread": {
             "hashes": [
-                "sha256:787b5fab9dd61a7d6d84af73356d7ff905cd3978438e528dc66dc8a9407fb851",
-                "sha256:8620e987e5340315f2b8d8d26cf97e4736a84b3325a17c7d9bcff70525dc3003"
+                "sha256:0fe52bec73cc232abadfbc2a999e30201bc5cb0c2728ec00fcfdf38f6f669375",
+                "sha256:9fca855173fdb2e648b3da9e7bbffb83601bfd7c7131d44fa781df84c689e7fc"
             ],
             "index": "pypi",
-            "version": "==5.5.0"
+            "version": "==5.6.0"
         },
         "httplib2": {
             "hashes": [
@@ -142,39 +143,47 @@
             "markers": "python_version >= '3.7'",
             "version": "==1.0.1"
         },
-        "numpy": {
+        "more-itertools": {
             "hashes": [
-                "sha256:004f0efcb2fe1c0bd6ae1fcfc69cc8b6bf2407e0f18be308612007a0762b4089",
-                "sha256:09f6b7bdffe57fc61d869a22f506049825d707b288039d30f26a0d0d8ea05164",
-                "sha256:0ea3f98a0ffce3f8f57675eb9119f3f4edb81888b6874bc1953f91e0b1d4f440",
-                "sha256:17c0e467ade9bda685d5ac7f5fa729d8d3e76b23195471adae2d6a6941bd2c18",
-                "sha256:1f27b5322ac4067e67c8f9378b41c746d8feac8bdd0e0ffede5324667b8a075c",
-                "sha256:22d43376ee0acd547f3149b9ec12eec2f0ca4a6ab2f61753c5b29bb3e795ac4d",
-                "sha256:2ad3ec9a748a8943e6eb4358201f7e1c12ede35f510b1a2221b70af4bb64295c",
-                "sha256:301c00cf5e60e08e04d842fc47df641d4a181e651c7135c50dc2762ffe293dbd",
-                "sha256:39a664e3d26ea854211867d20ebcc8023257c1800ae89773cbba9f9e97bae036",
-                "sha256:51bf49c0cd1d52be0a240aa66f3458afc4b95d8993d2d04f0d91fa60c10af6cd",
-                "sha256:78a63d2df1d947bd9d1b11d35564c2f9e4b57898aae4626638056ec1a231c40c",
-                "sha256:7cd1328e5bdf0dee621912f5833648e2daca72e3839ec1d6695e91089625f0b4",
-                "sha256:8355fc10fd33a5a70981a5b8a0de51d10af3688d7a9e4a34fcc8fa0d7467bb7f",
-                "sha256:8c79d7cf86d049d0c5089231a5bcd31edb03555bd93d81a16870aa98c6cfb79d",
-                "sha256:91b8d6768a75247026e951dce3b2aac79dc7e78622fc148329135ba189813584",
-                "sha256:94c15ca4e52671a59219146ff584488907b1f9b3fc232622b47e2cf832e94fb8",
-                "sha256:98dcbc02e39b1658dc4b4508442a560fe3ca5ca0d989f0df062534e5ca3a5c1a",
-                "sha256:a64403f634e5ffdcd85e0b12c08f04b3080d3e840aef118721021f9b48fc1460",
-                "sha256:bc6e8da415f359b578b00bcfb1d08411c96e9a97f9e6c7adada554a0812a6cc6",
-                "sha256:bdc9febce3e68b697d931941b263c59e0c74e8f18861f4064c1f712562903411",
-                "sha256:c1ba66c48b19cc9c2975c0d354f24058888cdc674bebadceb3cdc9ec403fb5d1",
-                "sha256:c9f707b5bb73bf277d812ded9896f9512a43edff72712f31667d0a8c2f8e71ee",
-                "sha256:d5422d6a1ea9b15577a9432e26608c73a78faf0b9039437b075cf322c92e98e7",
-                "sha256:e5d5420053bbb3dd64c30e58f9363d7a9c27444c3648e61460c1237f9ec3fa14",
-                "sha256:e868b0389c5ccfc092031a861d4e158ea164d8b7fdbb10e3b5689b4fc6498df6",
-                "sha256:efd9d3abe5774404becdb0748178b48a218f1d8c44e0375475732211ea47c67e",
-                "sha256:f8c02ec3c4c4fcb718fdf89a6c6f709b14949408e8cf2a2be5bfa9c49548fd85",
-                "sha256:ffcf105ecdd9396e05a8e58e81faaaf34d3f9875f137c7372450baa5d77c9a54"
+                "sha256:1bc4f91ee5b1b31ac7ceacc17c09befe6a40a503907baf9c839c229b5095cfd2",
+                "sha256:c09443cd3d5438b8dafccd867a6bc1cb0894389e90cb53d227456b0b0bccb750"
             ],
             "index": "pypi",
-            "version": "==1.23.3"
+            "version": "==8.14.0"
+        },
+        "numpy": {
+            "hashes": [
+                "sha256:0fe563fc8ed9dc4474cbf70742673fc4391d70f4363f917599a7fa99f042d5a8",
+                "sha256:12ac457b63ec8ded85d85c1e17d85efd3c2b0967ca39560b307a35a6703a4735",
+                "sha256:2341f4ab6dba0834b685cce16dad5f9b6606ea8a00e6da154f5dbded70fdc4dd",
+                "sha256:296d17aed51161dbad3c67ed6d164e51fcd18dbcd5dd4f9d0a9c6055dce30810",
+                "sha256:488a66cb667359534bc70028d653ba1cf307bae88eab5929cd707c761ff037db",
+                "sha256:4d52914c88b4930dafb6c48ba5115a96cbab40f45740239d9f4159c4ba779962",
+                "sha256:5e13030f8793e9ee42f9c7d5777465a560eb78fa7e11b1c053427f2ccab90c79",
+                "sha256:61be02e3bf810b60ab74e81d6d0d36246dbfb644a462458bb53b595791251911",
+                "sha256:7607b598217745cc40f751da38ffd03512d33ec06f3523fb0b5f82e09f6f676d",
+                "sha256:7a70a7d3ce4c0e9284e92285cba91a4a3f5214d87ee0e95928f3614a256a1488",
+                "sha256:7ab46e4e7ec63c8a5e6dbf5c1b9e1c92ba23a7ebecc86c336cb7bf3bd2fb10e5",
+                "sha256:8981d9b5619569899666170c7c9748920f4a5005bf79c72c07d08c8a035757b0",
+                "sha256:8c053d7557a8f022ec823196d242464b6955a7e7e5015b719e76003f63f82d0f",
+                "sha256:926db372bc4ac1edf81cfb6c59e2a881606b409ddc0d0920b988174b2e2a767f",
+                "sha256:95d79ada05005f6f4f337d3bb9de8a7774f259341c70bc88047a1f7b96a4bcb2",
+                "sha256:95de7dc7dc47a312f6feddd3da2500826defdccbc41608d0031276a24181a2c0",
+                "sha256:a0882323e0ca4245eb0a3d0a74f88ce581cc33aedcfa396e415e5bba7bf05f68",
+                "sha256:a8365b942f9c1a7d0f0dc974747d99dd0a0cdfc5949a33119caf05cb314682d3",
+                "sha256:a8aae2fb3180940011b4862b2dd3756616841c53db9734b27bb93813cd79fce6",
+                "sha256:c237129f0e732885c9a6076a537e974160482eab8f10db6292e92154d4c67d71",
+                "sha256:c67b833dbccefe97cdd3f52798d430b9d3430396af7cdb2a0c32954c3ef73894",
+                "sha256:ce03305dd694c4873b9429274fd41fc7eb4e0e4dea07e0af97a933b079a5814f",
+                "sha256:d331afac87c92373826af83d2b2b435f57b17a5c74e6268b79355b970626e329",
+                "sha256:dada341ebb79619fe00a291185bba370c9803b1e1d7051610e01ed809ef3a4ba",
+                "sha256:ed2cc92af0efad20198638c69bb0fc2870a58dabfba6eb722c933b48556c686c",
+                "sha256:f260da502d7441a45695199b4e7fd8ca87db659ba1c78f2bbf31f934fe76ae0e",
+                "sha256:f2f390aa4da44454db40a1f0201401f9036e8d578a25f01a6e237cea238337ef",
+                "sha256:f76025acc8e2114bb664294a07ede0727aa75d63a06d2fae96bf29a81747e4a7"
+            ],
+            "index": "pypi",
+            "version": "==1.23.4"
         },
         "oauth2client": {
             "hashes": [
@@ -186,11 +195,11 @@
         },
         "oauthlib": {
             "hashes": [
-                "sha256:1565237372795bf6ee3e5aba5e2a85bd5a65d0e2aa5c628b9a97b7d7a0da3721",
-                "sha256:88e912ca1ad915e1dcc1c06fc9259d19de8deacd6fd17cc2df266decc2e49066"
+                "sha256:8139f29aac13e25d502680e9e19963e83f16838d48a0d71c287fe40e7067fbca",
+                "sha256:9859c40929662bec5d64f34d01c99e093149682a3f38915dc0655d5a633dd918"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==3.2.1"
+            "version": "==3.2.2"
         },
         "pandas": {
             "hashes": [
@@ -414,11 +423,11 @@
     "develop": {
         "astroid": {
             "hashes": [
-                "sha256:81f870105d892e73bf535da77a8261aa5bde838fa4ed12bb2f435291a098c581",
-                "sha256:997e0c735df60d4a4caff27080a3afc51f9bdd693d3572a4a0b7090b645c36c5"
+                "sha256:2df4f9980c4511474687895cbfdb8558293c1a826d9118bb09233d7c2bff1c83",
+                "sha256:867a756bbf35b7bc07b35bfa6522acd01f91ad9919df675e8428072869792dce"
             ],
             "markers": "python_full_version >= '3.7.2'",
-            "version": "==2.12.10"
+            "version": "==2.12.11"
         },
         "dill": {
             "hashes": [
@@ -505,11 +514,11 @@
         },
         "pylint": {
             "hashes": [
-                "sha256:5fdfd44af182866999e6123139d265334267339f29961f00c89783155eacc60b",
-                "sha256:7f6aad1d8d50807f7bc64f89ac75256a9baf8e6ed491cc9bc65592bc3f462cf1"
+                "sha256:5441e9294335d354b7bad57c1044e5bd7cce25c433475d76b440e53452fa5cb8",
+                "sha256:629cf1dbdfb6609d7e7a45815a8bb59300e34aa35783b5ac563acaca2c4022e9"
             ],
             "index": "pypi",
-            "version": "==2.15.3"
+            "version": "==2.15.4"
         },
         "python-dateutil": {
             "hashes": [
@@ -545,19 +554,19 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02",
-                "sha256:e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6"
+                "sha256:1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa",
+                "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"
             ],
             "markers": "python_version < '3.10'",
-            "version": "==4.3.0"
+            "version": "==4.4.0"
         },
         "visidata": {
             "hashes": [
-                "sha256:30ca9d65608a8f9d62798bda4a689c2b443ee042ddb59b76fa123ac814c2e899",
-                "sha256:cd0850b42072ac5c2b5ee1a79b14212e654a22fe1cf448bd62f10cac9dc025e3"
+                "sha256:da530d8f16568595628d1f75903bbd1ec0919c2b51f7fa275b69ce015a32ab3e",
+                "sha256:fe10c88f585e8e1c79a60a7e5dc08e1097d84c73d741a1fa10db0422252b6318"
             ],
             "index": "pypi",
-            "version": "==2.10.1"
+            "version": "==2.10.2"
         },
         "wrapt": {
             "hashes": [
@@ -639,11 +648,11 @@
         },
         "zipp": {
             "hashes": [
-                "sha256:05b45f1ee8f807d0cc928485ca40a07cb491cf092ff587c0df9cb1fd154848d2",
-                "sha256:47c40d7fe183a6f21403a199b3e4192cca5774656965b0a4988ad2f8feb5f009"
+                "sha256:3a7af91c3db40ec72dd9d154ae18e008c69efe8ca88dde4f9a731bb82fe2f9eb",
+                "sha256:972cfa31bc2fedd3fa838a51e9bc7e64b7fb725a8c00e7431554311f180e9980"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.8.1"
+            "version": "==3.9.0"
         }
     }
 }

--- a/ordering/scripts/cascadia_return.py
+++ b/ordering/scripts/cascadia_return.py
@@ -4,7 +4,7 @@ import envdir, os, logging, sys, argparse
 BASE_DIR = os.path.abspath(__file__ + "/../../../")
 sys.path.append(BASE_DIR)
 
-from ordering.utils.redcap import init_project, get_redcap_report, format_longitudinal
+from ordering.utils.redcap import init_project, get_redcap_report, format_longitudinal, import_records_batched
 from ordering.utils.delivery_express import get_de_orders, format_orders_import
 from ordering.utils.cascadia import filter_cascadia_orders
 
@@ -35,7 +35,7 @@ def main(args):
     if len(formatted_import):
         if args.import_to_redcap:
             LOG.info(f'Importing {len(formatted_import)} new return orders to REDCap.')
-            redcap_project.import_records(formatted_import, overwrite='overwrite')
+            import_records_batched(redcap_project, formatted_import)
         else:
             LOG.info(f'Skipping import to REDCap due to <--import={args.import_to_redcap}>.')
     else:

--- a/ordering/scripts/cascadia_return.py
+++ b/ordering/scripts/cascadia_return.py
@@ -28,14 +28,14 @@ def main(args):
 
     redcap_orders = redcap_orders.astype({'Record Id': int})
     redcap_orders['orderId'] = redcap_orders.dropna(
-        subset=['Record Id']).apply(get_de_orders, axis=1
+        subset=['Record Id']).apply(get_de_orders, axis=1, max_retries=5
     )
     formatted_import = format_orders_import(redcap_orders)
 
     if len(formatted_import):
         if args.import_to_redcap:
-            LOG.info(f'Importing {len(formatted_import)} new return orders to REDCap.')
             import_records_batched(redcap_project, formatted_import)
+            LOG.info(f'Imported {len(formatted_import)} new return orders to REDCap.')
         else:
             LOG.info(f'Skipping import to REDCap due to <--import={args.import_to_redcap}>.')
     else:

--- a/ordering/utils/redcap.py
+++ b/ordering/utils/redcap.py
@@ -3,6 +3,7 @@ import os, logging, sys
 import pandas as pd
 from redcap import Project
 from urllib.parse import urlparse
+from more_itertools import chunked
 
 # Place all modules within this script's path
 # TODO: structure directory better so we don't need this
@@ -87,12 +88,6 @@ def import_records_batched(project, records, batch_size = 50):
     Import *records* to a REDCap *project* with the given *batch_size*, so as not to overload REDCap's servers
     with large import requests.
     """
-    total = len(records)
-    batches = [
-        (i, i + batch_size if i + batch_size < total else total) for i in range(0, total, batch_size)
-    ]
-
-    LOG.debug(f'Importing <{len(batches)}> batches of REDCap data.')
-    for lower_bound, upper_bound in batches:
-        project.import_records(records[lower_bound:upper_bound], overwrite='overwrite')
-        LOG.debug(f'Imported records <{lower_bound}> through <{upper_bound}> to REDCap.')
+    for chunk in chunked(range(len(records)), batch_size):
+        project.import_records(records.iloc[chunk], overwrite='overwrite')
+        LOG.debug(f'Imported records <{chunk[0]}> up to <{chunk[-1]}> to REDCap.')

--- a/ordering/utils/redcap.py
+++ b/ordering/utils/redcap.py
@@ -80,3 +80,19 @@ def get_cascadia_study_pause_reports(project):
 
     LOG.debug(f'Concatenated pause report has <{len(cascadia_study_pauses)}> pause events.')
     return cascadia_study_pauses.sort_index()
+
+
+def import_records_batched(project, records, batch_size = 50):
+    """
+    Import *records* to a REDCap *project* with the given *batch_size*, so as not to overload REDCap's servers
+    with large import requests.
+    """
+    total = len(records)
+    batches = [
+        (i, i + batch_size if i + batch_size < total else total) for i in range(0, total, batch_size)
+    ]
+
+    LOG.debug(f'Importing <{len(batches)}> batches of REDCap data.')
+    for lower_bound, upper_bound in batches:
+        project.import_records(records[lower_bound:upper_bound], overwrite='overwrite')
+        LOG.debug(f'Imported records <{lower_bound}> through <{upper_bound}> to REDCap.')


### PR DESCRIPTION
The growing size of the Cascadia project necessitates a couple of changes with how we handle our API requests:
- We should batch imports of DE order numbers to REDCap, since imports of too many records can cause the REDCap server to run out of memory and our import to fail
- We should retry failed requests to DE servers after a wait period because our repeated order searches are sometimes rejected and no content is returned

Both these issues previously caused the script to fail, but with batch sizes capped at 50 and with 5 attempts per record if needed, the script will be much more resilient to these problems.