### PR TITLE
Skip Archived Participants

### DIFF
--- a/ordering/scripts/usps_cascadia_order.py
+++ b/ordering/scripts/usps_cascadia_order.py
@@ -56,6 +56,10 @@ def main(args):
             LOG.debug(f'Working on participant <{participant}>.')
             pt_data = order_report.loc[[(house_id, participant)]]
 
+            if any(pt_data['manage_archive']):
+                LOG.debug(f'Participant <{participant}> is archived and no longer needs orders generated for them.')
+                continue
+
             # the participant should be enrolled and consented to get any kits
             if not (any(pt_data['enrollment_survey_complete'] == 2) and any(pt_data['consent_form_complete'] == 2)):
                 LOG.debug(f'Participant <{participant}> must be consented and enrolled to receive swab kits.')


### PR DESCRIPTION
Under certain scenarios, archived participants could show up in the order form. The archived variable has been added to the REDCap report and this logic change makes it explicit that archived participants will always be skipped.